### PR TITLE
Fixed crash on load for Apple Silicon devices and removed M1 launch script

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -26,7 +26,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "e8db6e2d014b3f1f0c4c5170ebb697bf508c641e"
+      "hash": "ea7d0bbfaa5a617f6b39a43b3b69ee7ec441f422"
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.20.4
+  bundleVersion: 1.20.5
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/steampipe/ContentBuilder/content/macos_content/play.sh
+++ b/steampipe/ContentBuilder/content/macos_content/play.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-open Fantasy\ Town\ Regional\ Manager.app


### PR DESCRIPTION
### Pull Request Description
<!-- Provide a brief description of what this PR does and how it can be tested below -->
This PR solves crashing on load for `v1.20.4` as below:
```
Mono path[0] = '/Users/shoshanabroyda/Library/Application Support/Steam/steamapps/common/Fantasy Town Regional Manager/Fantasy Town Regional Manager.app/Contents/Resources/Data/Managed'
...
Initializing Metal device caps: Apple M1
...
Fallback handler could not load library /Users/shoshanabroyda/Library/Application Support/Steam/steamapps/common/Fantasy Town Regional Manager/Fantasy Town Regional Manager.app/Contents/Frameworks/MonoEmbedRuntime/osx/libsteam_api
[Steamworks.NET] Could not load [lib]steam_api.dll/so/dylib. It's likely not in the correct location. Refer to the README for more details.
System.DllNotFoundException: steam_api
  at (wrapper managed-to-native) Steamworks.NativeMethods.SteamAPI_RestartAppIfNecessary(Steamworks.AppId_t)
  at Steamworks.SteamAPI.RestartAppIfNecessary (Steamworks.AppId_t unOwnAppID) [0x00005] in <33e3b4ace50646fab06793556fdf8f6e>:0 
  at Steamworks.NET.SteamManager.Awake () [0x00061] in <fbc75dd111274e88a925e7b69c839ae3>:0 
Steamworks initialised: False
```

The issue is caused by the game attempting to contact Steam on load, an issue previously solved for application launches by adding an indirection script, `play.sh`. With some digging it was found that [Steam has finally released an Apple silicon compatible "universal" binary for Steamworks SDK](https://store.steampowered.com/news/group/4145017/view/2984186817523157398), and with PR https://github.com/rlabrecque/Steamworks.NET/pull/452, it has been included in Steamworks.NET.

Upgrading to the latest Steamworks.NET has solved the issue, and after testing, it seems that the workaround is no longer necessary for Steam launches either and has been removed as well for this fix.

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Added walls mechanic")
- [x] linked to its related issue
- [x] assigned a reviewer from the team

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] pulled to the reviewer's machine and reasonably tested
- [x] read through and approved by a reviewer
- [x] bumped in project version over the [latest release](https://github.com/CapsCollective/ozymandias/releases) (i.e. vX.Y.Z for major, minor or patch)

_Note: for new features, use minor (Y), and for bug fixes or small changes, use patch (Z). Bumping the minor version should also reset the patch version to zero, so v1.2.4, would become v1.3.0. See [semantic versioning](https://semver.org) for more info._

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
