### PR TITLE
Added HUD transition animations for all UI elements

### DIFF
--- a/Assets/Prefabs/UI/Canvases/Game Canvas.prefab
+++ b/Assets/Prefabs/UI/Canvases/Game Canvas.prefab
@@ -307,6 +307,7 @@ GameObject:
   - component: {fileID: 2242881136027146499}
   - component: {fileID: 2242881136027146511}
   - component: {fileID: 2242881136027146496}
+  - component: {fileID: 2125698388087141293}
   m_Layer: 5
   m_Name: Game Canvas
   m_TagString: Untagged
@@ -419,6 +420,24 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &2125698388087141293
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2242881136027146497}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6aa2ebd4dc574f978b930b952abf611, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  animateInDuration: 0.5
+  animateOutDuration: 0.5
+  topBar: {fileID: 2242881137958832625}
+  leftButtons: {fileID: 2242881136392965917}
+  rightButtons: {fileID: 2242881135903982267}
+  cards: {fileID: 2242881137517192981}
 --- !u!1 &5008247059917132382
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Canvases/Menu Canvas.prefab
+++ b/Assets/Prefabs/UI/Canvases/Menu Canvas.prefab
@@ -251,6 +251,7 @@ GameObject:
   - component: {fileID: 7969370083710150783}
   - component: {fileID: 1382471725450256115}
   - component: {fileID: 7969370083710150782}
+  - component: {fileID: 6440151132372808200}
   m_Layer: 5
   m_Name: Menu Canvas
   m_TagString: Untagged
@@ -355,6 +356,23 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &6440151132372808200
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7969370083710150768}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6f1f6e58bb9482bbe9bb3615b25f579, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  animateInDuration: 0.5
+  animateOutDuration: 0.5
+  title: {fileID: 8375738213538244224}
+  buttons: {fileID: 7969370085179406789}
+  socials: {fileID: 4582825208007912323}
 --- !u!1 &7969370084023345986
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Achievements;
 using Events;
@@ -10,6 +9,7 @@ using Quests;
 using Requests.Templates;
 using Structures;
 using Tooltip;
+using UI;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -40,6 +40,8 @@ namespace Managers
         public TooltipDisplay Tooltip { get; private set; }
         public CameraMovement Camera { get; private set; }
         public CursorSelect Cursor { get; private set; }
+        public GameHud GameHud { get; private set; }
+        public IntroHud IntroHud { get; private set; }
 
         private void Awake()
         {
@@ -61,6 +63,8 @@ namespace Managers
             Tooltip = FindObjectOfType<TooltipDisplay>();
             Camera = FindObjectOfType<CameraMovement>();
             Cursor = FindObjectOfType<CursorSelect>();
+            GameHud = FindObjectOfType<GameHud>();
+            IntroHud = FindObjectOfType<IntroHud>();
             gameObject.AddComponent<AchievementManager>();
         }
         #endregion

--- a/Assets/Scripts/Tutorial/Tutorial.cs
+++ b/Assets/Scripts/Tutorial/Tutorial.cs
@@ -10,6 +10,7 @@ using Managers;
 using NaughtyAttributes;
 using Structures;
 using TMPro;
+using UI;
 using UnityEngine;
 using UnityEngine.UI;
 using Utilities;
@@ -25,7 +26,7 @@ namespace Tutorial
         FingerGuns,
         PointingUp
     }
-    
+
     public class Tutorial : MonoBehaviour
     {
         public static bool Active, DisableSelect;
@@ -34,7 +35,7 @@ namespace Tutorial
         
         [SerializeField] private Image guide;
         [SerializeField] private TextMeshProUGUI text;
-        [SerializeField] private RectTransform dialogue, objectives, topBar, leftButtons, rightButtons, cards, objectiveContainer;
+        [SerializeField] private RectTransform dialogue, objectives, objectiveContainer;
         [SerializeField] private GameObject objectivePrefab, blocker;
         [SerializeField] private Button next;
         
@@ -47,10 +48,8 @@ namespace Tutorial
         {
             Manager.Inputs.OnDialogueNext.performed += _ => NextLine();
             next.onClick.AddListener(NextLine);
-                
-            State.OnLoadingEnd += HideGameUi;
+            
             State.OnNewGame += StartTutorial;
-
         }
 
         private void ShowDialogue(List<Line> lines)
@@ -60,7 +59,7 @@ namespace Tutorial
             _sectionLine = 0;
             guide.GetComponent<RectTransform>().DOAnchorPosX(0, 0.5f);
             dialogue.DOAnchorPosY(230, 0.5f);
-            leftButtons.DOAnchorPosX(-150,0.5f);
+            Manager.GameHud.Hide(GameHud.HudObject.LeftButtons);
 
             text.text = lines[0].Dialogue;
             text.maxVisibleCharacters = lines[0].Dialogue.Length;
@@ -75,7 +74,7 @@ namespace Tutorial
             _currentSection = null;
             guide.GetComponent<RectTransform>().DOAnchorPosX(-600, 0.5f);
             dialogue.DOAnchorPosY(0, 0.5f);
-            leftButtons.DOAnchorPosX(10,0.5f);
+            Manager.GameHud.Show(GameHud.HudObject.LeftButtons);
             Manager.State.EnterState(GameState.InGame);
             blocker.SetActive(false);
         }
@@ -174,15 +173,7 @@ namespace Tutorial
         #endregion
 
         #region Section Callbacks
-        private void HideGameUi()
-        {
-            if (!Active) return;
-            topBar.anchoredPosition = new Vector2(0,200);
-            leftButtons.anchoredPosition = new Vector2(-150,0);
-            rightButtons.anchoredPosition = new Vector2(0,-230);
-            cards.anchoredPosition = new Vector2(0,-390);
-        }
-        
+
         [Button("Start Tutorial")]
         private void StartTutorial()
         {
@@ -262,7 +253,7 @@ namespace Tutorial
             Structures.Structures.OnBuild += Build;
             Cards.Cards.OnBuildingRotate += RotateBuilding;
             Manager.Cards.SetTutorialCards();
-            cards.DOAnchorPosY(-155,0.5f);
+            Manager.GameHud.Show(GameHud.HudObject.Cards);
 
             void ClearRuin(Structure structure)
             {
@@ -296,6 +287,16 @@ namespace Tutorial
                     });
             }
 
+            void ShowGameUi()
+            {
+                Manager.Stats.Wealth = 100;
+                Manager.GameHud.Show(new List<GameHud.HudObject>()
+                {
+                    GameHud.HudObject.TopBar,
+                    GameHud.HudObject.RightButtons
+                });
+            }
+
             ShowDialogue(new List<Line> {
                 new Line("Nice! That'll hopefully set us up for some success.", GuidePose.Neutral),
                 new Line("Now every adventuring town's lifeblood is the Guild Hall. I'll pop one in now, will even clear some space for you, you can thank me later.", onNext: SpawnGuildHall),
@@ -306,14 +307,6 @@ namespace Tutorial
                 new Line("As your population grows, you'll need to keep building to keep everyone happy."),
                 new Line("Try attracting some adventurers now!", onNext: StartAdventurerObjectives)
             });
-        }
-
-        private void ShowGameUi()
-        {
-            Manager.Stats.Wealth = 100;
-            topBar.DOAnchorPosY(0,0.5f);
-            rightButtons.DOAnchorPosY(0,0.5f);
-            UpdateUi();
         }
         
         private void StartAdventurerObjectives()

--- a/Assets/Scripts/UI/GameHud.cs
+++ b/Assets/Scripts/UI/GameHud.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using DG.Tweening;
+using UnityEngine;
+using static Managers.GameManager;
+using static UI.GameHud.HudObject;
+
+namespace UI
+{
+    public class GameHud : MonoBehaviour
+    {
+        [SerializeField] private float animateInDuration = 0.5f, animateOutDuration = 0.5f;
+        [SerializeField] private RectTransform topBar, leftButtons, rightButtons, cards;
+
+        public enum HudObject
+        {
+            TopBar,
+            LeftButtons,
+            RightButtons,
+            Cards,
+        }
+
+        private readonly struct HudObjectValues
+        {
+            public readonly RectTransform RectTransform;
+            public readonly Vector2 ShowPos;
+            public readonly Vector2 HidePos;
+
+            public HudObjectValues(RectTransform rect, Vector2 show, Vector2 hide)
+            {
+                RectTransform = rect;
+                ShowPos = show;
+                HidePos = hide;
+            }
+        }
+
+        private Dictionary<HudObject, HudObjectValues> _hudValuesMap;
+
+        private void Start()
+        {
+            _hudValuesMap = new Dictionary<HudObject, HudObjectValues>
+            {
+                {TopBar, new HudObjectValues(topBar, Vector2.zero, new Vector2(0,200))},
+                {LeftButtons, new HudObjectValues(leftButtons, new Vector2(10,0), new Vector2(-150,0))},
+                {RightButtons, new HudObjectValues(rightButtons, Vector2.zero, new Vector2(0,-230))},
+                {HudObject.Cards, new HudObjectValues(cards, new Vector2(0,-155), new Vector2(0,-390))},
+            };
+        }
+        
+        public void Hide(bool animate = true)
+        {
+            Hide(new List<HudObject>(_hudValuesMap.Keys), animate);
+        }
+
+        public void Hide(List<HudObject> objects, bool animate = true)
+        {
+            foreach (HudObject obj in objects) Hide(obj, animate);
+        }
+        
+        public void Hide(HudObject obj, bool animate = true)
+        {
+            HudObjectValues objValues = _hudValuesMap[obj];
+            if (animate) objValues.RectTransform.DOAnchorPos(objValues.HidePos, animateOutDuration);
+            else objValues.RectTransform.anchoredPosition = objValues.HidePos;
+        }
+        
+        public void Show(bool animate = true)
+        {
+            Show(new List<HudObject>(_hudValuesMap.Keys), animate);
+        }
+        
+        public void Show(List<HudObject> objects, bool animate = true)
+        {
+            foreach (HudObject obj in objects) _Show(obj, animate);
+            UpdateUi();
+        }
+
+        public void Show(HudObject obj, bool animate = true)
+        {
+            // Wraps UI updating functionality
+            _Show(obj, animate);
+            UpdateUi();
+        }
+
+        private void _Show(HudObject obj, bool animate = true)
+        {
+            HudObjectValues objValues = _hudValuesMap[obj];
+            if (animate) objValues.RectTransform.DOAnchorPos(objValues.ShowPos, animateInDuration);
+            else objValues.RectTransform.anchoredPosition = objValues.ShowPos;
+        }
+    }
+}

--- a/Assets/Scripts/UI/GameHud.cs.meta
+++ b/Assets/Scripts/UI/GameHud.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6aa2ebd4dc574f978b930b952abf611
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/IntroHud.cs
+++ b/Assets/Scripts/UI/IntroHud.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using DG.Tweening;
+using UnityEngine;
+
+namespace UI
+{
+    public class IntroHud : MonoBehaviour
+    {
+        [SerializeField] private float animateInDuration = 0.5f, animateOutDuration = 0.5f;
+        [SerializeField] private RectTransform title, buttons, socials;
+
+        public enum HudObject
+        {
+            Title,
+            Buttons,
+            Socials,
+        }
+
+        private readonly struct HudObjectValues
+        {
+            public readonly RectTransform RectTransform;
+            public readonly Vector2 ShowPos;
+            public readonly Vector2 HidePos;
+
+            public HudObjectValues(RectTransform rect, Vector2 show, Vector2 hide)
+            {
+                RectTransform = rect;
+                ShowPos = show;
+                HidePos = hide;
+            }
+        }
+
+        private Dictionary<HudObject, HudObjectValues> _hudValuesMap;
+
+        private void Start()
+        {
+            _hudValuesMap = new Dictionary<HudObject, HudObjectValues>
+            {
+                {HudObject.Title, new HudObjectValues(title, new Vector2(600,320), new Vector2(600,700))},
+                {HudObject.Buttons, new HudObjectValues(buttons, new Vector2(600,-100), new Vector2(-400,-100))},
+                {HudObject.Socials, new HudObjectValues(socials, Vector2.zero, new Vector2(250,0))},
+            };
+        }
+        
+        public void Hide(bool animate = true)
+        {
+            Hide(new List<HudObject>(_hudValuesMap.Keys), animate);
+        }
+
+        public void Hide(List<HudObject> objects, bool animate = true)
+        {
+            foreach (HudObject obj in objects) Hide(obj, animate);
+        }
+        
+        public void Hide(HudObject obj, bool animate = true)
+        {
+            HudObjectValues objValues = _hudValuesMap[obj];
+            if (animate) objValues.RectTransform.DOAnchorPos(objValues.HidePos, animateOutDuration);
+            else objValues.RectTransform.anchoredPosition = objValues.HidePos;
+        }
+        
+        public void Show(bool animate = true)
+        {
+            Show(new List<HudObject>(_hudValuesMap.Keys), animate);
+        }
+        
+        public void Show(List<HudObject> objects, bool animate = true)
+        {
+            foreach (HudObject obj in objects) Show(obj, animate);
+        }
+
+        public void Show(HudObject obj, bool animate = true)
+        {
+            HudObjectValues objValues = _hudValuesMap[obj];
+            if (animate) objValues.RectTransform.DOAnchorPos(objValues.ShowPos, animateInDuration);
+            else objValues.RectTransform.anchoredPosition = objValues.ShowPos;
+        }
+    }
+}

--- a/Assets/Scripts/UI/IntroHud.cs.meta
+++ b/Assets/Scripts/UI/IntroHud.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c6f1f6e58bb9482bbe9bb3615b25f579
+timeCreated: 1636024593

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.20.5
+  bundleVersion: 1.20.6
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
### Pull Request Description
<!-- Provide a brief description of what this PR does and how it can be tested below -->
This PR makes the in-game and in-menu UI elements animate in and out when changing states, preserving their operation in the tutorial.

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Added walls mechanic")
- [x] linked to its related issue
- [x] assigned a reviewer from the team

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] pulled to the reviewer's machine and reasonably tested
- [x] read through and approved by a reviewer
- [x] bumped in project version over the [latest release](https://github.com/CapsCollective/ozymandias/releases) (i.e. vX.Y.Z for major, minor or patch)

_Note: for new features, use minor (Y), and for bug fixes or small changes, use patch (Z). Bumping the minor version should also reset the patch version to zero, so v1.2.4, would become v1.3.0. See [semantic versioning](https://semver.org) for more info._

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
