### PR TITLE
Fixed various tutorial & controller related bugs

### DIFF
--- a/Assets/Prefabs/UI/Card Unlock.prefab
+++ b/Assets/Prefabs/UI/Card Unlock.prefab
@@ -1,76 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &7087805460273398784
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4385172946603812396}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 0
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 0
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1319551843273524588}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 4329489187428998327}
-        m_TargetAssemblyTypeName: Cards.UnlockDisplay, Assembly-CSharp
-        m_MethodName: Close
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &8029747787498185925
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4385172946603812396}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b30315317814043855b210969d82321, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  scaleTarget: 1.1
-  duration: 0.3
-  target: {fileID: 0}
 --- !u!1 &5479101368338435392
 GameObject:
   m_ObjectHideFlags: 0
@@ -99,6 +28,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3962419233097012652}
   m_RootOrder: 1
@@ -235,6 +165,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7239196166634177808}
   - {fileID: 5193326251751715005}
@@ -475,7 +406,7 @@ PrefabInstance:
     - target: {fileID: 5092715541015078470, guid: b7d2f3f91f10c405286e87e6c4a9f595,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 80
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5092715541015078470, guid: b7d2f3f91f10c405286e87e6c4a9f595,
         type: 3}
@@ -539,6 +470,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6842023823080394208, guid: b7d2f3f91f10c405286e87e6c4a9f595,
         type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6842023823080394208, guid: b7d2f3f91f10c405286e87e6c4a9f595,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -565,24 +501,21 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7691733660248703451}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &7239196166634177808 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1065186583844717771, guid: b7d2f3f91f10c405286e87e6c4a9f595,
-    type: 3}
-  m_PrefabInstance: {fileID: 7691733660248703451}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1319551843273524588 stripped
+--- !u!114 &8029747787498185925
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8714881357929366711, guid: b7d2f3f91f10c405286e87e6c4a9f595,
-    type: 3}
-  m_PrefabInstance: {fileID: 7691733660248703451}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4385172946603812396}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 4b30315317814043855b210969d82321, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  scaleTarget: 1.1
+  duration: 0.3
+  target: {fileID: 0}
 --- !u!114 &6418953316381266797 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3722844163552744118, guid: b7d2f3f91f10c405286e87e6c4a9f595,
@@ -595,3 +528,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e39f12ea1d5e24e29aa49a5454ff6370, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7239196166634177808 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1065186583844717771, guid: b7d2f3f91f10c405286e87e6c4a9f595,
+    type: 3}
+  m_PrefabInstance: {fileID: 7691733660248703451}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/Cards/UnlockDisplay.cs
+++ b/Assets/Scripts/Cards/UnlockDisplay.cs
@@ -35,7 +35,10 @@ namespace Cards
             Cards.OnUnlock += _buildings.Push;
             Cards.OnDiscoverRuin += CheckUnlockCard;
             Newspaper.OnClosed += CheckUnlockCard;
-            Manager.Inputs.LeftClick.performed += _ => Close();
+            Manager.Inputs.LeftClick.performed += _ =>
+            {
+                if (!Tutorial.Tutorial.ShowShade) Close();
+            };
         }
 
         private void CheckUnlockCard()

--- a/Assets/Scripts/Cards/UnlockDisplay.cs
+++ b/Assets/Scripts/Cards/UnlockDisplay.cs
@@ -5,7 +5,6 @@ using DG.Tweening;
 using Events;
 using Structures;
 using TMPro;
-using UI;
 using UnityEngine;
 using Utilities;
 using static Managers.GameManager;

--- a/Assets/Scripts/Cards/UnlockDisplay.cs
+++ b/Assets/Scripts/Cards/UnlockDisplay.cs
@@ -37,7 +37,7 @@ namespace Cards
             Newspaper.OnClosed += CheckUnlockCard;
             Manager.Inputs.LeftClick.performed += _ =>
             {
-                if (!Tutorial.Tutorial.ShowShade) Close();
+                if (!Tutorial.Tutorial.ShowShade && !Tutorial.Tutorial.DisableSelect) Close();
             };
         }
 

--- a/Assets/Scripts/Tutorial/Tutorial.cs
+++ b/Assets/Scripts/Tutorial/Tutorial.cs
@@ -79,9 +79,10 @@ namespace Tutorial
             Quests.Quests.OnCampAdded += StartCampsDescription;
         }
 
-        private void ShowDialogue(List<Line> lines, GameState exitState = GameState.InGame)
+        private void ShowDialogue(List<Line> lines, GameState exitState = GameState.InGame, bool showShade = false)
         {
             _exitState = exitState;
+            ShowShade = showShade;
             Manager.State.EnterState(GameState.InDialogue);
             _currentSection = lines;
             _sectionLine = 0;
@@ -99,6 +100,7 @@ namespace Tutorial
 
         private void HideDialogue()
         {
+            ShowShade = false;
             _currentSection = null;
             guide.GetComponent<RectTransform>().DOAnchorPosX(-600, 0.5f);
             dialogue.DOAnchorPosY(0, 0.5f);
@@ -414,15 +416,13 @@ namespace Tutorial
         private void StartUnlockDescription()
         {
             if (Manager.Cards.UnlockedCards != 1) return;
-            ShowShade = true;
             //TODO: Write Proper dialogue
             ShowDialogue(new List<Line> {
                 new Line("You've just unlocked a new building card! Keep an eye on news in the town, and you might be able to find more.", GuidePose.Neutral),
                 new Line("This building will be added to your cards, at least until they all get lost in the ruins of your town..."),
                 new Line("But fear not! Check the upgrades page in your book to purchase the ability to rediscover them from the ruins of your previous towns."),
                 new Line("Discovering more buildings might just give us the edge to lasting a little longer out here...")
-            }, GameState.InMenu);
-            ShowShade = false;
+            }, GameState.InMenu, true);
         }
         
         /*private void StartUpgradesDescription()

--- a/Assets/Scripts/Tutorial/Tutorial.cs
+++ b/Assets/Scripts/Tutorial/Tutorial.cs
@@ -51,6 +51,7 @@ namespace Tutorial
         private Action _onObjectivesComplete;
 
         private GameState _exitState = GameState.InGame;
+        private Action _exitAction = null;
         
         #region Dialogue
         
@@ -79,9 +80,10 @@ namespace Tutorial
             Quests.Quests.OnCampAdded += StartCampsDescription;
         }
 
-        private void ShowDialogue(List<Line> lines, GameState exitState = GameState.InGame, bool showShade = false)
+        private void ShowDialogue(List<Line> lines, GameState exitState = GameState.InGame, Action exitAction = null, bool showShade = false)
         {
             _exitState = exitState;
+            _exitAction = exitAction;
             ShowShade = showShade;
             Manager.State.EnterState(GameState.InDialogue);
             _currentSection = lines;
@@ -106,6 +108,7 @@ namespace Tutorial
             dialogue.DOAnchorPosY(0, 0.5f);
             Manager.GameHud.Show(GameHud.HudObject.MenuBar);
             Manager.State.EnterState(_exitState);
+            _exitAction?.Invoke();
             blocker.SetActive(false);
         }
 
@@ -267,8 +270,9 @@ namespace Tutorial
         
         private void StartBuildingObjectives()
         {
-            DisableSelect = false;
-            Manager.Camera.MoveTo(Manager.Structures.TownCentre);
+            // Workaround to make sure the selection is not active immediately after clicking next
+            // (to stop controllers selecting structures on exiting tutorial)
+            Manager.Camera.MoveTo(Manager.Structures.TownCentre).OnComplete(() => DisableSelect = false);
             
             ClearObjectives();
             _currentObjectives = new List<Objective>
@@ -343,7 +347,11 @@ namespace Tutorial
         private void StartAdventurerObjectives()
         {
             DisableNextTurn = false;
-            Manager.Camera.MoveTo(Manager.Structures.TownCentre);
+            
+            // Workaround to make sure the selection is not active immediately after clicking next
+            // (to stop controllers selecting structures on exiting tutorial)
+            DisableSelect = true;
+            Manager.Camera.MoveTo(Manager.Structures.TownCentre).OnComplete(() => DisableSelect = false);
             
             ClearObjectives();
             _currentObjectives = new List<Objective>
@@ -393,6 +401,11 @@ namespace Tutorial
 
         private void EndTutorial()
         {
+            // Workaround to make sure the selection is not active immediately after clicking next
+            // (to stop controllers selecting structures on exiting tutorial)
+            DisableSelect = true;
+            Manager.Camera.MoveTo(Manager.Structures.TownCentre).OnComplete(() => DisableSelect = false);
+            
             Active = false;
             foreach (Guild guild in Enum.GetValues(typeof(Guild)))
             {
@@ -416,13 +429,21 @@ namespace Tutorial
         private void StartUnlockDescription()
         {
             if (Manager.Cards.UnlockedCards != 1) return;
+            
+            // Workaround to make sure the selection is not active immediately after clicking next
+            // (to stop controllers closing the card on exiting tutorial)
+            DisableSelect = true;
+
             //TODO: Write Proper dialogue
             ShowDialogue(new List<Line> {
                 new Line("You've just unlocked a new building card! Keep an eye on news in the town, and you might be able to find more.", GuidePose.Neutral),
                 new Line("This building will be added to your cards, at least until they all get lost in the ruins of your town..."),
                 new Line("But fear not! Check the upgrades page in your book to purchase the ability to rediscover them from the ruins of your previous towns."),
                 new Line("Discovering more buildings might just give us the edge to lasting a little longer out here...")
-            }, GameState.InMenu, true);
+            },
+                GameState.InMenu,
+                () => StartCoroutine(Algorithms.DelayCall(0.5f, () => DisableSelect = false)),
+                true);
         }
         
         /*private void StartUpgradesDescription()

--- a/Assets/Scripts/Tutorial/Tutorial.cs
+++ b/Assets/Scripts/Tutorial/Tutorial.cs
@@ -417,7 +417,6 @@ namespace Tutorial
         private void StartCampsDescription(Quest quest)
         {
             if (Manager.Achievements.Milestones[Milestone.CampsCleared] > 0 || !quest.IsRadiant || Manager.Quests.RadiantCount > 1) return;
-            //TODO: Write Proper dialogue
             ShowDialogue(new List<Line> {
                 new Line("Heads up, our scouts have found an enemy camp!", GuidePose.Neutral),
                 new Line("They don't look too threatening right now, but give them a few days to grow and they could become a real problem. Each space they take up adds 1 threat until cleared."),
@@ -434,7 +433,6 @@ namespace Tutorial
             // (to stop controllers closing the card on exiting tutorial)
             DisableSelect = true;
 
-            //TODO: Write Proper dialogue
             ShowDialogue(new List<Line> {
                 new Line("You've just unlocked a new building card! Keep an eye on news in the town, and you might be able to find more.", GuidePose.Neutral),
                 new Line("This building will be added to your cards, at least until they all get lost in the ruins of your town..."),

--- a/Assets/Scripts/Utilities/Algorithms.cs
+++ b/Assets/Scripts/Utilities/Algorithms.cs
@@ -134,7 +134,7 @@ namespace Utilities
         {
             // Defer callback action by duration
             yield return new WaitForSeconds(duration);
-            callback();
+            callback?.Invoke();
         }
 
         private readonly struct Costs

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.1.2
+  bundleVersion: 2.1.3
   preloadedAssets:
   - {fileID: 0}
   metroInputSource: 0


### PR DESCRIPTION
### Pull Request Description
<!-- Provide a brief description of what this PR does and how it can be tested below -->
This PR fixes multiple bugs and issues with `v2.1.2`, including:
- Terrain being autoselected selected after tutorial dialogues when using controllers
- Structure buttons being disabled performing the selection progress animation
- Shade display hard-lock issues on exiting card unlock tutorial

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Added walls mechanic")
- [x] linked to its related issue
- [x] assigned a reviewer from the team

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] pulled to the reviewer's machine and reasonably tested
- [x] read through and approved by a reviewer
- [x] bumped in project version over the [latest release](https://github.com/CapsCollective/ozymandias/releases) (i.e. vX.Y.Z for major, minor or patch)

_Note: for new features, use minor (Y), and for bug fixes or small changes, use patch (Z). Bumping the minor version should also reset the patch version to zero, so v1.2.4, would become v1.3.0. See [semantic versioning](https://semver.org) for more info._

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
